### PR TITLE
Add python 3.7 classifier to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     keywords="wav numpy",
     py_modules=["wavio"],


### PR DESCRIPTION
I've been using wavio with python 3.7 for quite some time now, and I haven't noticed any problems