### PR TITLE
normalize option added for scale parameter in `write`

### DIFF
--- a/tests/test_wavio.py
+++ b/tests/test_wavio.py
@@ -236,6 +236,21 @@ class TestWavio(unittest.TestCase):
                                   dtype=np.int32, shape=(len(data_read), 1),
                                   data=data_read.reshape(-1, 1))
 
+    def test_write_24bit_with_normalization(self):
+        with temporary_filepath("testdata.wav") as filename:
+            data_written = np.array([0, 2**14, -2**14, 2**21],
+                                    dtype=np.int32)
+            data_read = np.array([0, 2**16, -2**16, 2**23 - 1],
+                                 dtype=np.int32)
+
+            wavio.write(filename, data_written, 44100, scale="normalize", sampwidth=3)
+
+            self.check_basic(filename, nchannels=1, sampwidth=3,
+                             framerate=44100)
+            self.check_wavio_read(filename, rate=44100, sampwidth=3,
+                                  dtype=np.int32, shape=(len(data_read), 1),
+                                  data=data_read.reshape(-1, 1))
+
     def test_write_8bit_with_normalization(self):
         with temporary_filepath("testdata.wav") as filename:
             data_written = np.array([128, 129, 140, 100, 128],

--- a/tests/test_wavio.py
+++ b/tests/test_wavio.py
@@ -251,6 +251,20 @@ class TestWavio(unittest.TestCase):
                                   dtype=np.uint8, shape=(len(data_read), 1),
                                   data=data_read.reshape(-1, 1))
 
+    def test_write_float_with_normalization(self):
+        with temporary_filepath("testdata.wav") as filename:
+            data_written = np.array([0, 1.5, -4.5])
+            data_read = np.array([0, 2**15 // 3, -2**15],
+                                 dtype=np.int16)
+
+            wavio.write(filename, data_written, 44100, sampwidth=2, scale="normalize")
+
+            self.check_basic(filename, nchannels=1, sampwidth=2,
+                             framerate=44100)
+            self.check_wavio_read(filename, rate=44100, sampwidth=2,
+                                  dtype=np.int16, shape=(len(data_read), 1),
+                                  data=data_read.reshape(-1, 1))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_wavio.py
+++ b/tests/test_wavio.py
@@ -221,6 +221,36 @@ class TestWavio(unittest.TestCase):
                                   dtype=np.int32, shape=(len(data), 1),
                                   data=data.reshape(-1, 1))
 
+    def test_write_32bit_with_normalization(self):
+        with temporary_filepath("testdata.wav") as filename:
+            data_written = np.array([0, 1, -1, 2**30],
+                                    dtype=np.int32)
+            data_read = np.array([0, 2, -2, 2**31 - 1],
+                                 dtype=np.int32)
+
+            wavio.write(filename, data_written, 44100, scale="normalize")
+
+            self.check_basic(filename, nchannels=1, sampwidth=4,
+                             framerate=44100)
+            self.check_wavio_read(filename, rate=44100, sampwidth=4,
+                                  dtype=np.int32, shape=(len(data_read), 1),
+                                  data=data_read.reshape(-1, 1))
+
+    def test_write_8bit_with_normalization(self):
+        with temporary_filepath("testdata.wav") as filename:
+            data_written = np.array([128, 129, 140, 100, 128],
+                                    dtype=np.uint8)
+            data_read = np.array([128, 132, 182, 0, 128],
+                                 dtype=np.uint8)
+
+            wavio.write(filename, data_written, 44100, scale="normalize")
+
+            self.check_basic(filename, nchannels=1, sampwidth=1,
+                             framerate=44100)
+            self.check_wavio_read(filename, rate=44100, sampwidth=1,
+                                  dtype=np.uint8, shape=(len(data_read), 1),
+                                  data=data_read.reshape(-1, 1))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/wavio.py
+++ b/wavio.py
@@ -295,6 +295,11 @@ def write(file, data, rate, scale=None, sampwidth=None):
         The string "dtype-limits" is not allowed when the `data` is a
         floating point array.
 
+        If `scale` is the string "normalize", then data is normalized to
+        the full range of the output format while avoiding a DC offset
+        introduced by the default behavior (i.e. for asymmetric signals
+        zero value stays at zero).
+
         If using `scale` results in values that exceed the limits of the
         output sample width, the data is clipped.  For example, the
         following code::

--- a/wavio.py
+++ b/wavio.py
@@ -383,7 +383,7 @@ def write(file, data, rate, scale=None, sampwidth=None):
     elif scale == "normalize":
         analog_zero = (outmin + outmax) / 2
         centered_data = data - analog_zero
-        halfrange = max(abs(centered_data.min()), abs(centered_data.max()))
+        halfrange = _np.abs(centered_data).max()
         data = _scale_to_sampwidth(data, sampwidth, vmin=analog_zero - halfrange, vmax=analog_zero + halfrange)
     else:
         if scale is None:

--- a/wavio.py
+++ b/wavio.py
@@ -375,6 +375,11 @@ def write(file, data, rate, scale=None, sampwidth=None):
             vmin = ii.min
             vmax = ii.max
             data = _scale_to_sampwidth(data, sampwidth, vmin, vmax)
+    elif scale == "normalize":
+        analog_zero = (outmin + outmax) / 2
+        centered_data = data - analog_zero
+        halfrange = max(abs(centered_data.min()), abs(centered_data.max()))
+        data = _scale_to_sampwidth(data, sampwidth, vmin=analog_zero - halfrange, vmax=analog_zero + halfrange)
     else:
         if scale is None:
             vmin = data.min()


### PR DESCRIPTION
My quick attempt to solve issues #12 and #13. Usage:

```python
wavio.write("smth.wav", data, 44100, scale="normalize")
```

In this case the behavior mimics standard normalize feature found in any DAW: make audio as loud as possible while keeping zeroes at zero, i.e. avoiding DC offset. This may even be the default setting as it is the most fitting for dealing with recorded audio which is almost never symmetric.

Tests for the behavior are included.