### PR TITLE
Update license field to use proper SPDX identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description=("A Python module for reading and writing WAV files using "
                  "numpy arrays."),
     long_description=_long_description,
-    license="BSD",
+    license="BSD-2-Clause",
     url="https://github.com/WarrenWeckesser/wavio",
     classifiers=[
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This changes the license field to be a valid [SPDX identifier](https://spdx.org/licenses) aligning with [PEP 639](https://peps.python.org/pep-0639/#project-source-metadata). This populates the `license_expression` field in the PyPI API and is used by downstream tools including deps.dev

This PR was generated by Claude after reviewing the license and manifest files in your repository, but opened and reviewed by me. Please let me know if the analysis is incorrect and thanks for being an OSS maintainer.

You could also consider adding a `LICENSE` file, and optionally a `license-files=["LICENSE"]` field to your `setup.py`